### PR TITLE
Added missing include of memory.h.

### DIFF
--- a/libpff/libpff_recover.c
+++ b/libpff/libpff_recover.c
@@ -21,6 +21,7 @@
 
 #include <common.h>
 #include <byte_stream.h>
+#include <memory.h>
 #include <types.h>
 
 #include "libpff_data_block.h"


### PR DESCRIPTION
libpff/libpff_recover.c should include memory.h, as it uses the `memory_allocate` and `memory_free` macros.
