### PR TITLE
Reset the result flag after use

### DIFF
--- a/libpff/libpff_local_descriptors.c
+++ b/libpff/libpff_local_descriptors.c
@@ -371,6 +371,8 @@ int libpff_local_descriptors_get_leaf_node_from_node_by_identifier(
 	{
 		return( 0 );
 	}
+	// Reset the result flag.
+	result = 0;
 	if( offsets_index_value == NULL )
 	{
 		libcerror_error_set(


### PR DESCRIPTION
I think this is a bug - the `result` variable is used for the result of this initial computation but isn't cleared afterwards. If the subsequent traversal fails to find a leaf node, it's possible for it to return this old value.