### PR TITLE
autogen.sh does not account for homebrew

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -30,7 +30,8 @@ if ! test -x "${BINDIR}/aclocal";
 then
 	# Default location of 64-bit MSYS2-MinGW installed binaries.
 	BINDIR="/mingw64/bin";
-fiif ! test -x "${BINDIR}/aclocal";
+fi
+if ! test -x "${BINDIR}/aclocal";
 then
 	# Default location of Homebrew installed binaries.
 	BINDIR="/opt/homebrew/bin";

--- a/autogen.sh
+++ b/autogen.sh
@@ -30,6 +30,10 @@ if ! test -x "${BINDIR}/aclocal";
 then
 	# Default location of 64-bit MSYS2-MinGW installed binaries.
 	BINDIR="/mingw64/bin";
+fiif ! test -x "${BINDIR}/aclocal";
+then
+	# Default location of Homebrew installed binaries.
+	BINDIR="/opt/homebrew/bin";
 fi
 
 if ! test -x "${BINDIR}/aclocal";


### PR DESCRIPTION
autogen.sh has checks for many package install locations but does not account for homebrew

if ! test -x "${BINDIR}/aclocal";
then
	# Default location of Homebrew installed binaries.
	BINDIR="/opt/homebrew/bin";
fi