### PR TITLE
Replace use of deprecated distutils by setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import sys
 import tarfile
 import zipfile
 
-from distutils.ccompiler import new_compiler
+from setuptools.ccompiler import new_compiler
 
 from setuptools import Extension
 from setuptools import setup


### PR DESCRIPTION
Package distutils was deprecated in Python 3.10 and has been removed in Python 3.12. The ccompiler class is now available in setuptools. See https://peps.python.org/pep-0632/#migration-advice and https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html for further details.