### PR TITLE
pfftools: fix subject truncation for non-ASCII message subjects

### DIFF
--- a/pfftools/export_handle.c
+++ b/pfftools/export_handle.c
@@ -5095,6 +5095,7 @@ int export_handle_export_message_subject_to_item_file(
 		/* Ignore the subject control codes for now
 		 */
 		if( ( value_string_size >= 3 )
+		 && ( value_string[ 0 ] > 0 )
 		 && ( value_string[ 0 ] < 0x20 ) )
 		{
 			result = item_file_write_string(


### PR DESCRIPTION
Did reproduce this when exporting a PST archive, containing MS Todo entires. Tasks with English titles did convert correctly, while titles in other languages have converted with the first letter cut away.

My understanding that this prefix cutting is due to MAPI subject-prefix control code removal, but affects non-ASCII languages. 

The proposed change was tested to correct exporting of non-English titles, e.g., to _not_ produce this:

```
  cyr byte0=-48  triggers=1   "Задача" -> "адача"
  cjk byte0=-28  triggers=1   "你好"   -> "\xa0好"
  ```